### PR TITLE
Reviewer fix for newer chrome

### DIFF
--- a/extension/chrome/src/js/stash_page.js
+++ b/extension/chrome/src/js/stash_page.js
@@ -7,7 +7,7 @@
 		return;
 
 	// workaround to fix missing firefox onMessageExternal
-	if(typeof window.chrome === 'undefined') {
+	if(!window.chrome || !window.chrome.runtime || typeof(window.chrome.runtime.sendMessage) !== 'function') {
 		window.communication = {
 			runtime : {
 				sendMessage(extId, msg, callback) {


### PR DESCRIPTION
It seems that newer version of chrome doesn't include window.chrome.runtime.sendMessage and it causes issue #49.  This PR adds more strict checking to make sure that the function exists and is a function; if not, fallback to the previous implementation of sendMessage.