### PR TITLE
Fix pr edit reviewers for new bitbucket

### DIFF
--- a/extension/chrome/src/js/stash_page.js
+++ b/extension/chrome/src/js/stash_page.js
@@ -2129,7 +2129,7 @@
 							// replace jira link
 							prDetailsPage.replaceJiraLink();
 							// Reviewers groups (edit page)
-							AJS.bind("show.dialog", function() {
+							AJS.dialog2.on("show", function() {
 								if(window.featuresData.prtemplate == 1)
 									prCreateUtil.injectTemplateButton(template);
 								if(window.featuresData.reviewersgroup == 1)

--- a/extension/chrome/src/js/stash_page.js
+++ b/extension/chrome/src/js/stash_page.js
@@ -7,7 +7,7 @@
 		return;
 
 	// workaround to fix missing firefox onMessageExternal
-	if(typeof window.chrome === 'undefined') {
+	if(!window.chrome || !window.chrome.runtime || typeof(window.chrome.runtime.sendMessage) !== 'function') {
 		window.communication = {
 			runtime : {
 				sendMessage(extId, msg, callback) {


### PR DESCRIPTION
Based on the branch from #50 

Reviewer groups do not pop up for me in new bitbucket because the plugin is listening for an old, deprecated dialog event that bitbucket (at least the instance we're running) no longer seems to use.

Old dialog: https://docs.atlassian.com/aui/7.8.0/docs/dialog.html?_ga=2.162510652.1878890867.1526064900-1734121638.1523970510
New dialog (and events): https://docs.atlassian.com/aui/7.8.0/docs/dialog2.html

This will allow reviewer button show on when attempting to edit an existing PR on bitbucket using their newer dialog.