### PR TITLE
Reducing the domains on which the extension is active by default and giving user the ability to add more hosts

### DIFF
--- a/extension/chrome/src/js/userhosts.js
+++ b/extension/chrome/src/js/userhosts.js
@@ -1,0 +1,27 @@
+document.getElementById('save_user_hosts').addEventListener('click', (event) => {
+	
+	let hostsButton = document.getElementById('user_defined_hosts'),
+		hosts = hostsButton.value.
+		replace(/,/g, ' ').
+		replace(/;/g, ' ').
+		replace(/\r/g, ' ').
+		replace(/\t/g, ' ').
+		replace(/\n/g, ' ').
+		split(' ');
+
+	let fhosts = [];
+
+	for(let host of hosts){
+		if (host != "") {
+			fhosts.push(host)
+		}
+	}
+	hosts = fhosts
+	if (hosts.length > 0) {
+		chrome.storage.sync.get('user_defined_hosts', oldhosts => {
+			chrome.storage.sync.set({'user_defined_hosts': (oldhosts.user_defined_hosts || []).concat(hosts)})
+			chrome.extension.getBackgroundPage().handleUserDefinedHosts()
+		});
+		hostsButton.value = ''	
+	}
+})

--- a/extension/chrome/src/manifest.json
+++ b/extension/chrome/src/manifest.json
@@ -19,7 +19,8 @@
 		"default_icon": {
 			"19": "img/stash48.png",
 			"38": "img/stash48.png"
-		}
+		},
+		"default_popup": "userhosts.html"
 	},
 	"content_scripts": [
 		{

--- a/extension/chrome/src/manifest.json
+++ b/extension/chrome/src/manifest.json
@@ -28,7 +28,7 @@
 				"js/storage.js",
 				"js/injector_loader.js"
 			],
-			"matches": ["<all_urls>"]
+			"matches": ["*://*.bitbucket.org/*", "*://*.atlassian.com/*"]
 		}
 	],
 	"background": {

--- a/extension/chrome/src/userhosts.html
+++ b/extension/chrome/src/userhosts.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<meta name="description" content="User defined Bitbucket Hosts">
+	<meta name="author" content="MESOLIDO">
+
+	<title>Self Hosted Bitbucket Servers</title>
+	
+</head>
+
+<body>
+	<div class="container" id="bitbucket-extension-userdefined-hosts">
+		<h1>Adding more bitbucket servers</h1>
+		<p>By default, this extension is only enabled on <a href="https://bitbucket.org">bitbucket.org</a> and <a href="https://atlassian.com">atlassian.com</a>. But you can add more hosts (i.e. self-hosted bitbucket servers) where to enable it. Make sure that the hosts you type follow <a href="https://developer.chrome.com/extensions/match_patterns"> the URLs match patterns for extensions</a></p>
+		<div class="form-group">
+			<label for="user_defined_hosts"> </label>
+			<textarea class="form-control" rows="5" cols="50" id="user_defined_hosts" placeholder="*://*.bitbucket.org/**://*.atlassian.com/*"></textarea>
+			<button id="save_user_hosts" class="btn btn-default">Save</button>
+		</div>
+	</div>
+	<!-- Scripts -->
+	<script src="js/userhosts.js"></script>
+</body>
+</html>


### PR DESCRIPTION
The following modifications are proposed 
- By default, the extension is only active on bitbucket.org and atlassian.com domains
- But the user can add more domains, in particular other bitbucket servers. The added hosts should follow the URL matching patterns for extensions, at https://developer.chrome.com/extensions/match_patterns
